### PR TITLE
remove pinterest fields as required fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.16.11] - 2021-11-10
+
+### Changed
+
+- Program Messages
+    - Removed "image" as a required field for the "HOSTED" source
+    - Removed "pinterestShareBody" as a required field for the "PINTEREST" share medium
+    - Removed "pinterestImageURL" as a required field for the "PINTEREST" share medium
+
+[unreleased]: https://github.com/saasquatch/schema/compare/v1.16.11...HEAD
+[1.16.11]: https://github.com/saasquatch/schema/releases/tag/v1.16.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.16.11] - 2021-11-10
+## [1.16.11] - 2021-11-17
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.16.8",
+  "version": "1.16.11-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "@saasquatch/schema",
-<<<<<<< HEAD
-  "version": "1.16.11-0",
-=======
   "version": "1.16.10",
->>>>>>> master
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.16.11-0",
+  "version": "1.16.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.16.10",
+  "version": "1.16.11-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.16.11-0",
+  "version": "1.16.11",
   "main": "index.js",
   "repository": "git@github.com:saasquatch/schema.git",
   "author": "SaaSquatch <hello@saasquat.ch>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.16.10",
+  "version": "1.16.11-0",
   "main": "index.js",
   "repository": "git@github.com:saasquatch/schema.git",
   "author": "SaaSquatch <hello@saasquat.ch>",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "deploy": "np --no-cleanup --no-yarn --any-branch",
+    "deploy:alpha": "np --no-cleanup --no-yarn --any-branch --tag=alpha",
     "version": "npm run generate && git add --all",
     "generate": "npm run generate:version && npm run generate:types && npm run generate:yaml",
     "generate:version": "cd compilers && ts-node Version.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.16.10",
+  "version": "1.16.11",
   "main": "index.js",
   "repository": "git@github.com:saasquatch/schema.git",
   "author": "SaaSquatch <hello@saasquat.ch>",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "scripts": {
-    "deploy": "np patch --no-cleanup --no-yarn --any-branch",
+    "deploy": "np --no-cleanup --no-yarn --any-branch",
     "deploy:alpha": "np prerelease --no-cleanup --no-yarn --any-branch --tag=alpha",
     "version": "npm run generate && git add --all",
     "generate": "npm run generate:version && npm run generate:types && npm run generate:yaml",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.16.11",
+  "version": "1.16.10",
   "main": "index.js",
   "repository": "git@github.com:saasquatch/schema.git",
   "author": "SaaSquatch <hello@saasquat.ch>",
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "scripts": {
-    "deploy": "np --no-cleanup --no-yarn --any-branch",
+    "deploy": "np patch --no-cleanup --no-yarn --any-branch",
     "deploy:alpha": "np prerelease --no-cleanup --no-yarn --any-branch --tag=alpha",
     "version": "npm run generate && git add --all",
     "generate": "npm run generate:version && npm run generate:types && npm run generate:yaml",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "deploy": "np --no-cleanup --no-yarn --any-branch",
-    "deploy:alpha": "np --no-cleanup --no-yarn --any-branch --tag=alpha",
+    "deploy:alpha": "np prerelease --no-cleanup --no-yarn --any-branch --tag=alpha",
     "version": "npm run generate && git add --all",
     "generate": "npm run generate:version && npm run generate:types && npm run generate:yaml",
     "generate:version": "cd compilers && ts-node Version.ts",

--- a/src/json/ProgramMessages.schema.json
+++ b/src/json/ProgramMessages.schema.json
@@ -322,10 +322,6 @@
 						}
 					},
 					"additionalProperties": false,
-					"required": [
-						"pinterestShareBody",
-						"pinterestImageURL"
-					]
 				}
 			},
 			"additionalProperties": false

--- a/src/json/ProgramMessages.schema.json
+++ b/src/json/ProgramMessages.schema.json
@@ -92,8 +92,7 @@
 							"required": [
 								"source",
 								"title",
-								"description",
-								"image"
+								"description"
 							]
 						},
 						{

--- a/src/json/ProgramMessages.schema.json
+++ b/src/json/ProgramMessages.schema.json
@@ -321,7 +321,7 @@
 							"minLength": 4
 						}
 					},
-					"additionalProperties": false,
+					"additionalProperties": false
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Description of the change

> Remove Pinterest fields as required fields to be able to save Social Messaging settings. Since it is barely used, success has been asking to make the pinterest option optional

DS: Also remove the HOSTED image field as required

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: DEV-3158
 - Process.st launch checklist:  https://app.process.st/runs/DEV-3158-Update-Cloudinary-widget-to-20-mXkc2dGlWq3iUbVqF3RDOw

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [ ] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
