### PR TITLE
[DEV-3364] Reward Exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated files:
-index.d.ts
+/index.d.ts
 /types
 /json
 /yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Generated files:
 index.d.ts
+/types
+/json
+/yaml
 
 # Logs
 logs
@@ -59,6 +62,3 @@ typings/
 
 # dotenv environment variables file
 .env
-
-/json
-/yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.0] - 2023-01-18
+
+### Added
+
+- Added support for Integration Introspection
+- Added support for the units field in program introspection to return which units a reward can potentially have
+- Added support for importing the TypeScript types using ES6 syntax (old namespace method still works)
+
 ## [1.23.0] - 2022-11-29
 
 ### Added
@@ -85,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed "pinterestShareBody" as a required field for the "PINTEREST" share medium
   - Removed "pinterestImageURL" as a required field for the "PINTEREST" share medium
 
+[1.24.0]: https://github.com/saasquatch/schema/releases/tag/v1.24.0
 [1.23.0]: https://github.com/saasquatch/schema/releases/tag/v1.23.0
 [1.22.0]: https://github.com/saasquatch/schema/releases/tag/v1.22.0
 [1.21.2]: https://github.com/saasquatch/schema/releases/tag/v1.21.2

--- a/compilers/SchemaToTypescript.ts
+++ b/compilers/SchemaToTypescript.ts
@@ -1,7 +1,7 @@
-import { compile, compileFromFile } from "json-schema-to-typescript";
-import glob from "glob";
-import path from "path";
 import fs from "fs";
+import glob from "glob";
+import { compileFromFile } from "json-schema-to-typescript";
+import path from "path";
 
 const SCHEMAS_GLOB = "**/*.schema.json";
 const SCHEMAS_BASE = path.resolve(__dirname, "../json");
@@ -9,52 +9,99 @@ const SCHEMAS_FOLDER = path.resolve(__dirname, "../json", SCHEMAS_GLOB);
 const TYPEDEFS_FOLDER = path.resolve(__dirname, "../src/types");
 
 const HEADER = `/***
-
-SaaSquatch Type Definitions
-
-This file was automatically generated. DO NOT edit it by hand, instead edit the related JSON Schema file.
-
-Generated on ${new Date().toISOString()}
-
-
-***/
+ * 
+ * SaaSquatch Type Definitions
+ * 
+ * This file was automatically generated. DO NOT edit it by hand, instead edit the related JSON Schema file.
+ * 
+ * Generated on ${new Date().toISOString()}
+ * 
+ ***/
 
 `;
 
 glob(SCHEMAS_FOLDER, async (err, matches) => {
   console.log("Compiling schemas: ", matches.length);
 
-  const outFile = path.resolve(__dirname, "../index.d.ts"); // index.d.ts is a standard for type definitions
-  fs.writeFileSync(outFile, HEADER); // Empties type file
+  const rootOut = path.resolve(__dirname, "../types/index.js");
+  const rootDTsOut = path.resolve(__dirname, "../types/index.d.ts");
+
+  if (!fs.existsSync(path.dirname(rootOut))) {
+    fs.mkdirSync(path.dirname(rootOut), { recursive: true });
+  }
+
+  fs.writeFileSync(rootOut, "module.exports = {}");
+  fs.writeFileSync(rootDTsOut, "");
 
   const outFilePaths = [];
   const outErrors = [];
   for (let filepath of matches) {
     try {
+      const filename = path.basename(filepath);
+      const baseFileName = filename.split(".")[0];
+      const relativePath = path.relative(SCHEMAS_BASE, filepath);
+      const relativeBaseName = relativePath.replace(".schema.json", "");
+
+      const indexFolder = path.resolve(
+        __dirname,
+        "../types/",
+        relativeBaseName
+      );
+
+      fs.mkdirSync(indexFolder, { recursive: true });
+
+      // index.js file is needed so the types can be imported by the consuming module
+      const indexOut = path.resolve(
+        __dirname,
+        "../types/",
+        relativeBaseName,
+        "index.js"
+      );
+
+      const indexDTsOut = path.resolve(
+        __dirname,
+        "../types/",
+        relativeBaseName,
+        "index.d.ts"
+      );
+
+      const packageJsonOut = path.resolve(
+        __dirname,
+        "../types/",
+        relativeBaseName,
+        "package.json"
+      );
+
+      fs.writeFileSync(indexOut, "module.exports = {}");
+      fs.writeFileSync(indexDTsOut, HEADER); // Empties type file
+      fs.writeFileSync(
+        packageJsonOut,
+        JSON.stringify({
+          name: `@saasquatch/schema/${relativeBaseName}`,
+          main: "index.js",
+          types: "index.d.ts",
+        })
+      ); // Empties type file
+
       const typedef = await compileFromFile(filepath, {
         bannerComment: "",
         declareExternallyReferenced: true,
         cwd: SCHEMAS_BASE,
         unreachableDefinitions: true,
         ignoreMinAndMaxItems: true,
+        format: false,
       });
-      const filename = path.basename(filepath);
-      const baseFileName = filename.split(".")[0];
-      fs.appendFileSync(outFile, `// ${filename} \n`);
+
+      fs.appendFileSync(indexDTsOut, `/*** \n * ${filename}\n`);
       fs.appendFileSync(
-        outFile,
-        `// Generated on ${new Date().toISOString()} \n`
+        indexDTsOut,
+        ` * Generated on ${new Date().toISOString()}\n`
       );
       fs.appendFileSync(
-        outFile,
-        `// This file was automatically generated. DO NOT edit it by hand, instead edit the related JSON Schema file. \n`
+        indexDTsOut,
+        ` * This file was automatically generated. DO NOT edit it by hand, instead edit the related JSON Schema file.\n ***/\n\n`
       );
-      fs.appendFileSync(
-        outFile,
-        `declare namespace saasquatch.${baseFileName} {\n`
-      );
-      fs.appendFileSync(outFile, typedef);
-      fs.appendFileSync(outFile, `} // End of ${baseFileName} \n\n\n`);
+      fs.appendFileSync(indexDTsOut, typedef);
       outFilePaths.push(filepath);
     } catch (e) {
       outErrors.push(filepath);

--- a/compilers/SchemaToTypescript.ts
+++ b/compilers/SchemaToTypescript.ts
@@ -38,7 +38,6 @@ glob(SCHEMAS_FOLDER, async (err, matches) => {
   for (let filepath of matches) {
     try {
       const filename = path.basename(filepath);
-      const baseFileName = filename.split(".")[0];
       const relativePath = path.relative(SCHEMAS_BASE, filepath);
       const relativeBaseName = relativePath.replace(".schema.json", "");
 
@@ -65,23 +64,8 @@ glob(SCHEMAS_FOLDER, async (err, matches) => {
         "index.d.ts"
       );
 
-      const packageJsonOut = path.resolve(
-        __dirname,
-        "../types/",
-        relativeBaseName,
-        "package.json"
-      );
-
       fs.writeFileSync(indexOut, "module.exports = {}");
       fs.writeFileSync(indexDTsOut, HEADER); // Empties type file
-      fs.writeFileSync(
-        packageJsonOut,
-        JSON.stringify({
-          name: `@saasquatch/schema/${relativeBaseName}`,
-          main: "index.js",
-          types: "index.d.ts",
-        })
-      ); // Empties type file
 
       const typedef = await compileFromFile(filepath, {
         bannerComment: "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.1-1",
+  "version": "1.23.1-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/schema",
-      "version": "1.23.1-1",
+      "version": "1.23.1-2",
       "license": "MIT",
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.0",
+  "version": "1.23.1-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/schema",
-      "version": "1.23.0",
+      "version": "1.23.1-0",
       "license": "MIT",
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.1-2",
+  "version": "1.23.1-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/schema",
-      "version": "1.23.1-2",
+      "version": "1.23.1-3",
       "license": "MIT",
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.1-0",
+  "version": "1.23.1-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/schema",
-      "version": "1.23.1-0",
+      "version": "1.23.1-1",
       "license": "MIT",
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.1-3",
+  "version": "1.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/schema",
-      "version": "1.23.1-3",
+      "version": "1.24.0",
       "license": "MIT",
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.1-1",
+  "version": "1.23.1-2",
   "main": "types/index.js",
   "types": "index.d.ts",
   "repository": "git@github.com:saasquatch/schema.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.1-2",
+  "version": "1.23.1-3",
   "main": "types/index.js",
   "types": "index.d.ts",
   "repository": "git@github.com:saasquatch/schema.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.1-0",
+  "version": "1.23.1-1",
   "main": "types/index.js",
   "types": "types/index.d.ts",
   "repository": "git@github.com:saasquatch/schema.git",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@saasquatch/schema",
   "version": "1.23.1-0",
-  "types": "./index.d.ts",
+  "main": "types/index.js",
+  "types": "types/index.d.ts",
   "repository": "git@github.com:saasquatch/schema.git",
   "author": "SaaSquatch <hello@saasquat.ch>",
   "license": "MIT",
   "files": [
+    "types/",
     "json/",
-    "yaml/",
-    "index.d.ts"
+    "yaml/"
   ],
   "publishConfig": {
     "access": "public"
@@ -19,7 +20,7 @@
     "version": "npm run generate && git add --all",
     "generate": "npm run validate:yaml && npm run generate:version && npm run generate:types && npm run generate:yaml",
     "generate:version": "cd compilers && ts-node Version.ts",
-    "generate:types": "cd compilers && ts-node SchemaToTypescript.ts",
+    "generate:types": "shx rm -Rf types && cd compilers && ts-node SchemaToTypescript.ts",
     "generate:yaml": "shx rm -Rf yaml && shx mkdir yaml && shx cp src/yaml/*.yaml yaml/",
     "validate:yaml": "swagger-cli validate src/yaml/saasquatch-api.yaml",
     "test": "npm run generate && ajv compile -s \"json/*.schema.json\" && jest",
@@ -62,5 +63,6 @@
   "np": {
     "releaseDraft": false
   },
-  "prettier": {}
+  "prettier": {},
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.1-3",
+  "version": "1.24.0",
   "main": "types/index.js",
   "types": "index.d.ts",
   "repository": "git@github.com:saasquatch/schema.git",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "@saasquatch/schema",
   "version": "1.23.1-1",
   "main": "types/index.js",
-  "types": "types/index.d.ts",
+  "types": "index.d.ts",
   "repository": "git@github.com:saasquatch/schema.git",
   "author": "SaaSquatch <hello@saasquat.ch>",
   "license": "MIT",
   "files": [
     "types/",
     "json/",
-    "yaml/"
+    "yaml/",
+    "index.d.ts"
   ],
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/schema",
-  "version": "1.23.0",
+  "version": "1.23.1-0",
   "types": "./index.d.ts",
   "repository": "git@github.com:saasquatch/schema.git",
   "author": "SaaSquatch <hello@saasquat.ch>",

--- a/src/json/IntegrationConfig.schema.json
+++ b/src/json/IntegrationConfig.schema.json
@@ -31,25 +31,13 @@
         "$ref": "#/definitions/customField"
       }
     },
-    "rewardUnitSettingsList": {
+    "fulfilledRewardUnits": {
       "type": "array",
-      "title": "Reward Unit Settings List",
-      "description": "A list of reward unit settings managed by this integration",
+      "title": "Fulfilled Reward Units",
+      "description": "A list of reward units fulfilled by this integration",
       "items": {
-        "anyOf": [
-          { "$ref": "UnitSettings.schema.json#" },
-          {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "title": "Reward Unit Settings Id"
-              }
-            },
-            "required": ["id"],
-            "additionalProperties": false
-          }
-        ]
+        "type": "string",
+        "title": "Reward Unit"
       }
     }
   },

--- a/src/json/IntegrationConfig.schema.json
+++ b/src/json/IntegrationConfig.schema.json
@@ -30,6 +30,27 @@
       "items": {
         "$ref": "#/definitions/customField"
       }
+    },
+    "rewardUnitSettingsList": {
+      "type": "array",
+      "title": "Reward Unit Settings List",
+      "description": "A list of reward unit settings managed by this integration",
+      "items": {
+        "anyOf": [
+          { "$ref": "UnitSettings.schema.json#" },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "title": "Reward Unit Settings Id"
+              }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+          }
+        ]
+      }
     }
   },
   "additionalProperties": false,

--- a/src/json/ProgramTemplate.schema.json
+++ b/src/json/ProgramTemplate.schema.json
@@ -355,6 +355,14 @@
           "title": "Description",
           "description": "A human-readable description that explains this reward type. Displayed in the SaaSquatch portal during program setup. e.g. `This reward is given to people when they make their first purchase.`",
           "default": "This reward is given to people when they make their first purchase."
+        },
+        "units": {
+          "type": "array",
+          "title": "Units",
+          "description": "A list of reward units this reward can potentially have",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
## Description of the change

* Added support for Integration Introspection
* Added support for the `units` field in program introspection to return which units a reward can potentially have
* Added support for importing the TypeScript types using ES6 syntax (old namespace method still works)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: https://saasquatch.atlassian.net/browse/DEV-3364
- Process.st launch checklist: [Link](https://app.process.st/runs/Reward-Exchange-Midstack-Launch-nA_QldyqgtL5D-dQgwdPzg/tasks/qBvpKTmwIaUys0BnmCFFIA)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [x] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [x] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
